### PR TITLE
Fix session initialization order

### DIFF
--- a/bottom_nav.php
+++ b/bottom_nav.php
@@ -1,7 +1,4 @@
 <?php
-if (session_status() === PHP_SESSION_NONE) {
-    session_start();
-}
 $isLoggedIn = !empty($_SESSION['user']);
 ?>
 <nav class="bottom-nav">

--- a/header.php
+++ b/header.php
@@ -1,7 +1,4 @@
 <?php
-if (session_status() === PHP_SESSION_NONE) {
-    session_start();
-}
 $isLoggedIn = !empty($_SESSION['user']);
 ?>
 <header>

--- a/register.php
+++ b/register.php
@@ -1,3 +1,7 @@
+<?php
+session_start();
+$isLoggedIn = !empty($_SESSION['user']);
+?>
 <!DOCTYPE html>
 <html lang="fr">
 <head>


### PR DESCRIPTION
## Summary
- start session at the top of each entry page
- remove redundant session initialization from shared components

## Testing
- `php -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68642c9fb6dc8324ac54e19e4a96d783