### PR TITLE
Improve ebook CSS responsiveness

### DIFF
--- a/ebook/ebook.css
+++ b/ebook/ebook.css
@@ -247,3 +247,19 @@ body {
   .chapter, .quiz, .summary { padding: 1.25rem 0.5rem 2.375rem 0.5rem; }
   .cover { padding: 2.125rem 0.5625rem 1.5625rem 0.5625rem; }
 }
+
+@media (max-width: 480px) {
+  .ebook-container { max-width: 100vw; margin: 0; border-radius: 0; }
+  .chapter, .quiz, .summary { padding: 1rem 0.5rem 1.5rem 0.5rem; }
+  .cover { padding: 1.5rem 0.5rem 1rem 0.5rem; }
+  .cover h1 { font-size: 1.75rem; }
+  .nav-btn { font-size: 1rem; }
+  .chapter-title { font-size: 1.3rem; }
+}
+
+@media (min-width: 1024px) {
+  .ebook-container { max-width: 48rem; }
+  .cover h1 { font-size: 3rem; }
+  .nav-btn { font-size: 1.2rem; }
+  .chapter-title { font-size: 1.75rem; }
+}


### PR DESCRIPTION
## Summary
- expand ebook responsive design with new breakpoints at `480px` and `1024px`
- tweak container width, font sizes and spacing for these breakpoints

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68685907006c83249c1a3512b3ca6e66